### PR TITLE
ci(actions): update `prettier` nixpkgs reference

### DIFF
--- a/.github/workflows/lints.yaml
+++ b/.github/workflows/lints.yaml
@@ -28,7 +28,7 @@ jobs:
         run: nix profile install 'nixpkgs#treefmt'
 
       - name: Install prettier
-        run: nix profile install 'nixpkgs#nodePackages.prettier'
+        run: nix profile install 'nixpkgs#prettier'
 
       - name: Install nixpkgs-fmt
         run: nix profile install 'nixpkgs#nixpkgs-fmt'


### PR DESCRIPTION
- Update the Prettier installation command in the `lints.yaml` workflow.
- Remove the `nodePackages.` prefix from the nixpkgs reference.
